### PR TITLE
Cabal extra libraries

### DIFF
--- a/HPi.cabal
+++ b/HPi.cabal
@@ -19,6 +19,7 @@ library
   exposed-modules:     System.RaspberryPi.GPIO
   -- other-modules:       
   build-depends:    base < 5, bytestring < 0.11
+  extra-libraries: bcm2835
   
 source-repository head
   type:     git

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ HPi is a small library to access the GPIO pins on a Raspberry Pi from Haskell. I
 
 ===
 
-In order to compile programs including this library, you will need to have the bcm2835 library installed. It can be found at http://airspayce.com/mikem/bcm2835/index.html. In addition, when compiling your program, include the file /path/to/bcm2835 library/src/bcm2835.o. For example, the example in the /test directory should be compiled as: ghc --make gpiotest.hs ~/bcm2835-1.45/src/bcm2835.o. Note that you cannot access the memory map without root privileges, programs should be run with sudo.
+In order to compile programs including this library, you will need to have the bcm2835 library installed. It can be found at http://airspayce.com/mikem/bcm2835/index.html. When performing the cabal install for HPi you may need to pass the `--extra-lib-dirs` and `--extra-include-dirs` flags if you have installed bcm2835 at a non-standard path. Note that you cannot access the memory map without root privileges, programs should be run with sudo.
 
 ===
 


### PR DESCRIPTION
Changed the cabal file to include bcm2835 in the `extra-libraries` field. With this change, cabal will know to build `HPi` against bcm2835 when installing, and no special steps are required to compile programs that have a dependency on `HPi`. This is great because it makes it much easier to use cabal sandboxes and large projects, you don't need to pass command line flags to GHC but instead can use `cabal repl` etc.
