### PR TITLE
Add functions for PWM control

### DIFF
--- a/HPi.cabal
+++ b/HPi.cabal
@@ -3,7 +3,7 @@
 
 name:                HPi
 version:             0.9.0
-synopsis:            GPIO, I2C and SPI functions for the Raspberry Pi.
+synopsis:            GPIO, I2C, SPI, and PWM functions for the Raspberry Pi.
 description:         This package is a FFI wrapper around the bcm2835 library by Mike McCauley, it also includes a few utility functions for easier use of the imported functions.
 homepage:            https://github.com/WJWH/HPi
 license:             BSD3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Library to access the GPIO pins on a Raspberry Pi from Haskell. Works with all R
 
 ===
 
-HPi is a small library to access the GPIO pins on a Raspberry Pi from Haskell. It also includes some functions to use the I2C and SPI functionality of the Raspberry Pi, see the haddock documentation for details. It is constructed as a FFI wrapper around the `bcm2835` library, which is written in C. Because this library accesses the GPIO pins directly via a memory map, it should be faster than libraries which access the GPIO pins via the `/sys/class/gpio` interface.
+HPi is a small library to access the GPIO pins on a Raspberry Pi from Haskell. It also includes some functions to use the I2C, SPI, and PWM functionality of the Raspberry Pi, see the haddock documentation for details. It is constructed as a FFI wrapper around the `bcm2835` library, which is written in C. Because this library accesses the GPIO pins directly via a memory map, it should be faster than libraries which access the GPIO pins via the `/sys/class/gpio` interface.
 
 ===
 

--- a/System/RaspberryPi/GPIO.hs
+++ b/System/RaspberryPi/GPIO.hs
@@ -36,7 +36,16 @@ module System.RaspberryPi.GPIO (
     setDataModeSPI,
     transferAUXSPI,
     transferSPI,
-    transferManySPI
+    transferManySPI,
+    -- *PWM specific functions
+    -- |Allows control of 2 independent PWM channels. A limited subset of GPIO
+    -- pins can be connected to one of these 2 channels, allowing PWM control
+    -- of GPIO pins. You have to set the desired pin into a particular Alt Fun
+    -- to PWM output.
+    setClockPWM,
+    setModePWM,
+    setRangePWM,
+    setDataPWM
     ) where
 
 -- FFI wrapper over the I2C portions of the BCM2835 library by Mike McCauley, also some utility functions to
@@ -163,6 +172,19 @@ foreign import ccall unsafe "bcm2835.h bcm2835_aux_spi_transfer"       c_transfe
 
 --Sets the SPI clock divider and therefore the SPI clock speed.
 foreign import ccall unsafe "bcm2835.h bcm2835_aux_spi_setClockDivider"     c_setClockDividerAUXSPI :: CUShort -> IO ()
+
+------------------------------------------- PWM functions --------------------------------------------------------------------------
+-- sets the PWM clock
+foreign import ccall unsafe "bcm2835.h bcm2835_pwm_set_clock" c_setClockPWM :: CUInt -> IO ()
+
+-- sets the PWM pulse ratio to emit to DATA/RANGE
+foreign import ccall unsafe "bcm2835.h bcm2835_pwm_set_data" c_setDataPWM :: CUChar -> CUInt -> IO ()
+
+-- sets the mode of the given PWM channel
+foreign import ccall unsafe "bcm2835.h bcm2835_pwm_set_mode" c_setModePWM :: CUChar -> CUChar -> CUChar -> IO ()
+
+-- sets the maximum range of the PWM output
+foreign import ccall unsafe "bcm2835.h bcm2835_pwm_set_range" c_setRangePWM :: CUChar -> CUInt -> IO ()
 
 ------------------------------------------------------------------------------------------------------------------------------------
 ------------------------------------------ Exportable functions --------------------------------------------------------------------
@@ -371,3 +393,22 @@ setClockDividerAUXSPI a = c_setClockDividerAUXSPI $ fromIntegral a
 -- on MOSI, and simultaneously clocks in data from MISO. Returns the read data byte from the slave.
 transferAUXSPI :: Word8 -> IO Word8
 transferAUXSPI input = fromIntegral <$> c_transferAUXSPI (fromIntegral input)
+
+-------------------------------------------- PWM functions -------------------------------------------------------------------------
+
+-- |Sets the PWM clock divisor, to control the basic PWM pulse widths. 
+setClockPWM :: Word32 -> IO ()
+setClockPWM a = c_setClockPWM $ fromIntegral a
+
+-- |Sets the mode of the given PWM channel, allowing you to control the PWM mode and enable/disable that channel 
+setModePWM :: Word8 -> Word8 -> Word8 -> IO ()
+setModePWM a b c = c_setModePWM (fromIntegral a) (fromIntegral b) (fromIntegral c)
+
+-- |Sets the maximum range of the PWM output. The data value can vary between 0 and this range to control PWM output 
+setRangePWM :: Word8 -> Word32 -> IO ()
+setRangePWM a b = c_setRangePWM (fromIntegral a) (fromIntegral b)
+
+-- |Sets the PWM pulse ratio to emit to DATA/RANGE, where RANGE is set by 'setRangePWM'.
+setDataPWM :: Word8 -> Word32 -> IO ()
+setDataPWM a b = c_setDataPWM (fromIntegral a) (fromIntegral b)
+


### PR DESCRIPTION
Adds FFI bindings to the PWM functions (already available in version 1.63) and top-level exported functions to use them.